### PR TITLE
Fix for  inkscape 0.91 

### DIFF
--- a/extensions/kmlaser_boxmaker.py
+++ b/extensions/kmlaser_boxmaker.py
@@ -38,6 +38,10 @@ __version__ = "0.8" ### please report bugs, suggestions etc to bugs@twot.eu ###
 import sys,inkex,simplestyle,gettext
 _ = gettext.gettext
 
+# Support for Inkscape 0.48 and 0.91 unittouu
+if not hasattr(self, 'unittouu'):
+  self.unittouu = inkex.unittouu
+
 def drawS(XYstring):         # Draw lines from a list
   name='part'
   style = { 'stroke': '#000000', 'fill': 'none' }

--- a/extensions/kmlaser_boxmaker.py
+++ b/extensions/kmlaser_boxmaker.py
@@ -142,8 +142,8 @@ class BoxMaker(inkex.Effect):
     svg = self.document.getroot()
     
         # Get the attibutes:
-    widthDoc  = inkex.unittouu(svg.get('width'))
-    heightDoc = inkex.unittouu(svg.get('height'))
+    widthDoc  = self.unittouu(svg.get('width'))
+    heightDoc = self.unittouu(svg.get('height'))
 
         # Create a new layer.
     layer = inkex.etree.SubElement(svg, 'g')
@@ -155,16 +155,16 @@ class BoxMaker(inkex.Effect):
         # Get script's option values.
     unit=self.options.unit
     inside=self.options.inside
-    X = inkex.unittouu( str(self.options.length)  + unit )
-    Y = inkex.unittouu( str(self.options.width) + unit )
-    Z = inkex.unittouu( str(self.options.height)  + unit )
-    thickness = inkex.unittouu( str(self.options.thickness)  + unit )
-    nomTab = inkex.unittouu( str(self.options.tab) + unit )
+    X = self.unittouu( str(self.options.length)  + unit )
+    Y = self.unittouu( str(self.options.width) + unit )
+    Z = self.unittouu( str(self.options.height)  + unit )
+    thickness = self.unittouu( str(self.options.thickness)  + unit )
+    nomTab = self.unittouu( str(self.options.tab) + unit )
     equalTabs=self.options.equal
-    kerf = inkex.unittouu( str(self.options.kerf)  + unit )
-    clearance = inkex.unittouu( str(self.options.clearance)  + unit )
+    kerf = self.unittouu( str(self.options.kerf)  + unit )
+    clearance = self.unittouu( str(self.options.clearance)  + unit )
     layout=self.options.style
-    spacing = inkex.unittouu( str(self.options.spacing)  + unit )
+    spacing = self.unittouu( str(self.options.spacing)  + unit )
     
     if inside: # if inside dimension selected correct values to outside dimension
       X+=thickness*2

--- a/extensions/kmlaser_ptg.py
+++ b/extensions/kmlaser_ptg.py
@@ -45,6 +45,9 @@ _ = gettext.gettext
 if "errormsg" not in dir(inkex):
     inkex.errormsg = lambda msg: sys.stderr.write((unicode(msg) + "\n").encode("UTF-8"))
 
+# Support for Inkscape 0.48 and 0.91 unittouu
+if not hasattr(self, 'unittouu'):
+    self.unittouu = inkex.unittouu
 
 def bezierslopeatt(((bx0,by0),(bx1,by1),(bx2,by2),(bx3,by3)),t):
     ax,ay,bx,by,cx,cy,x0,y0=bezmisc.bezierparameterize(((bx0,by0),(bx1,by1),(bx2,by2),(bx3,by3)))

--- a/extensions/kmlaser_ptg.py
+++ b/extensions/kmlaser_ptg.py
@@ -4749,7 +4749,7 @@ class Gcodetools(inkex.Effect):
                 attr["transform"] = transform 
 
             orientation_group = inkex.etree.SubElement(layer, inkex.addNS('g','svg'), attr)
-            doc_height = inkex.unittouu(self.document.getroot().get('height'))
+            doc_height = self.unittouu(self.document.getroot().get('height'))
             if self.document.getroot().get('height') == "100%" :
                 doc_height = 1052.3622047
                 print_("Overruding height from 100 percents to %s" % doc_height)


### PR DESCRIPTION
There was a breaking change in how units are handled in Inkscape 0.91.  See notes [here](http://wiki.inkscape.org/wiki/index.php/Notes_On_Units_Handling_in_Extensions_in_0.91):  [http://wiki.inkscape.org/wiki/index.php/Notes_On_Units_Handling_in_Extensions_in_0.91](http://wiki.inkscape.org/wiki/index.php/Notes_On_Units_Handling_in_Extensions_in_0.91)