### PR TITLE
Modifying end position of a cut

### DIFF
--- a/extensions/kmlaser_ptg.py
+++ b/extensions/kmlaser_ptg.py
@@ -97,7 +97,7 @@ G01 Z-0.000001 F10000
 """,
 'footer': """(Footer)
 M5 (LOCK)
-G00 X0.0000 Y0.0000 (GO HOME)
+G53 G0 X0 Y255 (Move head out of way)
 M2 (END)
 %"""
 }


### PR DESCRIPTION
This command should move the laser head to a absolute position that is out of the way after a cut is done.  This should work even with offsets.