### PR TITLE
README instructs user how to find extensions folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,22 @@ A bundle of Inkscape extensions useful for Laser Cutting/Engraving.
 
 __Installation__
 
-Copy all the files from `extensions` to the respective Inkscape directories and then restart Inkscape.
+Copy all the files from `extensions` to the respective Inkscape
+directories and then restart Inkscape.
+
+To find the correct location, start Inkscape and check in the menu
+under Preferences -> System -> User extensions.
+
+The following are common values:
 
 Linux or Mac:
 ```
 ~/.config/inkscape/extensions
+```
+
+MacOS Catalina with Inkscape 1.0:
+```
+~/Library/Application\ Support/org.inkscape.Inkscape/config/inkscape/extensions
 ```
 
 Windows:


### PR DESCRIPTION
Summary: Added instructions on how end user can find correct location to install extensions.

I am on MacOS Catalina with Inkscape 1.0, and the current instructions did not work for me.  This PR provides the location I needed, but also provides instructions so that future users who may have similar issues can find the authoritative location to install user extensions for their system.

Closes issue #15 